### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -2,9 +2,11 @@
 # It is triggered by a push to the main branch or any release branch. The release branch must be in the format "releases/x.y.z"
 # and is created by the create release branch workflow.
 name: Build, Push, and Release
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
-  push:
     branches:
       - main
       - "releases/**"

--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -7,6 +7,7 @@ permissions:
   pull-requests: write
 
 on:
+  push:
     branches:
       - main
       - "releases/**"


### PR DESCRIPTION
Potential fix for [https://github.com/viscalyx/relabeler/security/code-scanning/10](https://github.com/viscalyx/relabeler/security/code-scanning/10)

To fix this issue, an explicit `permissions` block should be added. This block should be placed at the workflow level (just below `name:` and before `on:`), granting only the minimum permissions required for the workflow to function. Based on the steps, this workflow needs to create branches, push commits, create and tag releases, and open pull requests, which generally require `contents: write` and `pull-requests: write`. If finer granularity is known, only grant what's essential, but for most workflows doing similar operations, both are required. 

**Steps:**
- Add a `permissions:` block below the workflow `name:` before the `on:` block in `.github/workflows/build-push-release.yml`.
- Set:
  ```yaml
  permissions:
    contents: write
    pull-requests: write
  ```
- No code steps/invocations need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/relabeler/194)
<!-- Reviewable:end -->
