### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,4 +1,6 @@
 name: Create Release Branch
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/viscalyx/relabeler/security/code-scanning/8](https://github.com/viscalyx/relabeler/security/code-scanning/8)

To fix this problem, you should explicitly declare a `permissions:` block in your workflow YAML file. This sets the permissions that the GitHub Actions workflow will give to the `GITHUB_TOKEN` used in the workflow. In this case, since the workflow involves pushing a branch to the repository (`git push`), it requires `contents: write`. Therefore, add a `permissions:` key with `contents: write` at either the workflow level (recommended, covers all jobs) or directly under the job if preferred. 

The fix should be:
- At the top-level of the workflow YAML (after `name` and before `on`), add:
  ```yaml
  permissions:
    contents: write
  ```

This change is entirely within `.github/workflows/create-release-branch.yml`. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
