### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,4 +1,6 @@
 name: Lint Dockerfile
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/viscalyx/relabeler/security/code-scanning/4](https://github.com/viscalyx/relabeler/security/code-scanning/4)

To fix the problem, explicitly declare a `permissions` block at the top of your workflow file, immediately after the `name` (or `on:` trigger), but before the `jobs:` block. Set `contents: read` as a safe minimum starting point, as this suffices for the operations performed in this workflow (including code checkout and artifact upload). This change ensures that the GITHUB_TOKEN will be limited to reading repository contents during this workflow, preventing unintended or excessive repository access. No new methods, imports, or dependency changes are required—just a workflow YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/relabeler/196)
<!-- Reviewable:end -->
